### PR TITLE
WIP using robusta-jni

### DIFF
--- a/RustBootstrap/Cargo.toml
+++ b/RustBootstrap/Cargo.toml
@@ -7,7 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-jni = "0.19.0"
+#jni = "0.19.0"
+#robusta_jni = "0.2"
+robusta_jni = { git = "https://github.com/kitlith/robusta", branch = "fix_missing_package" }
+#lazy_static = "1.4.0"
 
 [lib]
 crate_type = ["cdylib"]

--- a/RustBootstrap/src/MinecraftClient.rs
+++ b/RustBootstrap/src/MinecraftClient.rs
@@ -1,17 +1,17 @@
-use jni::JNIEnv;
+//use jni::JNIEnv;
 
-struct MinecraftClient<'a> (JNIEnv<'a>);
-
-impl MinecraftClient<'_> {
-    fn get_instance() -> &'static MinecraftClient<'static> {
-        todo!("Your jni stuff would go here")
-    }
-
-    fn field_resource_manager<'a>(&self) -> &ResourceManager<'a> {
-        todo!("Your jni stuff would go here")
-    }
-
-    fn open_screen(&self, screen: &Screen) {
-        todo!("Your jni stuff would go here")
-    }
-}
+// struct MinecraftClient<'a> (JNIEnv<'a>);
+//
+// impl MinecraftClient<'_> {
+//     fn get_instance() -> &'static MinecraftClient<'static> {
+//         todo!("Your jni stuff would go here")
+//     }
+//
+//     fn field_resource_manager<'a>(&self) -> &ResourceManager<'a> {
+//         todo!("Your jni stuff would go here")
+//     }
+//
+//     fn open_screen(&self, screen: &Screen) {
+//         todo!("Your jni stuff would go here")
+//     }
+// }

--- a/RustBootstrap/src/bridge.rs
+++ b/RustBootstrap/src/bridge.rs
@@ -1,5 +1,7 @@
 use std::borrow::Borrow;
 
+use robusta_jni::jni;
+
 use jni::JNIEnv;
 use jni::objects::{JClass, JObject, JString, JValue};
 use jni::strings::JNIString;
@@ -17,7 +19,7 @@ pub struct Value<'a> {
 }
 
 impl Class<'a> {
-    pub fn method(&self, env: JNIEnv<'a>, name: &str, signature: &str, args: &[JValue]) -> Value<'a> {
+    pub fn method(&self, env: &JNIEnv<'a>, name: &str, signature: &str, args: &[JValue]) -> Value<'a> {
         let raw_result = env.call_static_method(self.j_class, name, signature, args);
         env.exception_describe();
         Value {
@@ -25,7 +27,7 @@ impl Class<'a> {
         }
     }
 
-    pub fn new(&self, env: JNIEnv<'a>, signature: &str, args: &[JValue]) -> Value<'a> {
+    pub fn new(&self, env: &JNIEnv<'a>, signature: &str, args: &[JValue]) -> Value<'a> {
         let raw_result = env.new_object(self.j_class, signature, args);
         env.exception_describe();
         Value {
@@ -33,7 +35,7 @@ impl Class<'a> {
         }
     }
 
-    pub fn field(&self, env: JNIEnv<'a>, name: &str, signature: &str) -> Value<'a> {
+    pub fn field(&self, env: &JNIEnv<'a>, name: &str, signature: &str) -> Value<'a> {
         let raw_result = env.get_static_field(self.j_class, name, signature);
         env.exception_describe();
         Value {
@@ -43,7 +45,7 @@ impl Class<'a> {
 }
 
 impl Object<'a> {
-    pub fn method(&self, env: JNIEnv<'a>, name: &str, signature: &str, args: &[JValue]) -> Value<'a> {
+    pub fn method(&self, env: &JNIEnv<'a>, name: &str, signature: &str, args: &[JValue]) -> Value<'a> {
         let raw_result = env.call_method(self.j_object, name, signature, args);
         env.exception_describe();
         Value {
@@ -69,7 +71,7 @@ pub fn jstring<'a>(env: &'a JNIEnv, string: &'a str) -> JString<'a> {
     env.new_string(string).unwrap()
 }
 
-pub fn class(env: JNIEnv<'a>, class: &str) -> Class<'a> {
+pub fn class(env: &JNIEnv<'a>, class: &str) -> Class<'a> {
     let clean_string = class.replace(".", "/");
     Class {
         j_class: env.find_class(clean_string.as_str()).unwrap(),

--- a/RustBootstrap/src/lib.rs
+++ b/RustBootstrap/src/lib.rs
@@ -63,7 +63,7 @@ mod some_jni {
         }
 
         // TODO: actually be able to pass/return object
-        pub extern "java" fn register(&self, env: &'borrow JNIEnv<'env>, ident: Identifier, obj: ()) -> JniResult<()> {}
+        pub extern "java" fn register(&self, env: &'borrow JNIEnv<'env>, ident: Identifier, obj: JObject) -> JniResult<JObject> {}
     }
 
     #[derive(Signature, TryIntoJavaValue, IntoJavaValue, TryFromJavaValue)]
@@ -158,7 +158,7 @@ mod some_jni {
             let block_settings = BlockSettings::of(env, block_material)?;
             let block = Block::new(env, block_settings)?;
 
-            let obj = block_registry.register(env, block_id, ())?;
+            let obj = block_registry.register(env, block_id, block.raw.as_obj())?;
 
             logger.info(env, "Hello, im printing this from rust!".to_string());
 

--- a/RustBootstrap/src/util.rs
+++ b/RustBootstrap/src/util.rs
@@ -1,6 +1,8 @@
 use std::borrow::Borrow;
 use std::ffi::CStr;
 
+use robusta_jni::jni;
+
 use jni::JNIEnv;
 use jni::objects::{JObject, JString};
 


### PR DESCRIPTION
This ran into at least of couple issues that need to be fixed in robusta/fixed upstream, so mainly just take this as something to consider/something to look into.

For simpler cases, where we can control what we're importing/exporting, robusta should work much better, but in this language adapter scenario, it really struggles. it seems very usable for some other rust <-> java jni though, especially if it's mainly java calling into rust, and not primarily rust calling java (which is what this is so far).